### PR TITLE
feat: Integrate Google Maps for city location display

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,6 +37,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 
@@ -74,4 +75,11 @@ dependencies {
     // Coil
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)
+
+    // Google Maps
+    implementation(libs.maps.compose)
+    implementation(libs.play.services.maps)
+
+    // Navigation
+    implementation(libs.androidx.navigation.compose)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="" />
+
+        <meta-data
+            android:name="com.google.android.gms.version"
+            android:value="@integer/google_play_services_version" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/klivvrassesment/MainActivity.kt
+++ b/app/src/main/java/com/klivvrassesment/MainActivity.kt
@@ -7,11 +7,9 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
-import com.klivvrassesment.ui.screens.main.MainScreenRoot
+import androidx.navigation.compose.rememberNavController
+import com.klivvrassesment.ui.navigation.MainNavHost
 import com.klivvrassesment.ui.theme.KlivvrAssesmentTheme
 import org.koin.compose.KoinContext
 
@@ -23,29 +21,15 @@ class MainActivity : ComponentActivity() {
             KlivvrAssesmentTheme {
                 KoinContext {
                     Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                        MainScreenRoot(
+                        val navController = rememberNavController()
+                        MainNavHost(
                             modifier = Modifier
-                                .padding(innerPadding)
+                                .padding(innerPadding),
+                            navController = navController
                         )
                     }
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    KlivvrAssesmentTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/klivvrassesment/ui/models/CityUiModel.kt
+++ b/app/src/main/java/com/klivvrassesment/ui/models/CityUiModel.kt
@@ -1,21 +1,43 @@
 package com.klivvrassesment.ui.models
 
+import android.os.Bundle
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
+import androidx.navigation.NavType
 import com.klivvrassesment.domain.entity.CityEntity
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
 @Stable
 @Immutable
+@Serializable
 data class CityUiModel(
     val country: String,
     val name: String,
     val id: Int,
     val coordinates: CoordinatesUiModel
 ){
+    @Serializable
     data class CoordinatesUiModel(
-        val lon: Double,
+        val lng: Double,
         val lat: Double
     )
+}
+
+// NavType
+val CityUiModelNavType = object : NavType<CityUiModel>(isNullableAllowed = false) {
+    override fun get(bundle: Bundle, key: String): CityUiModel {
+        val json = bundle.getString(key)
+        return Json.decodeFromString(json!!)
+    }
+
+    override fun parseValue(value: String): CityUiModel {
+        return Json.decodeFromString(value)
+    }
+
+    override fun put(bundle: Bundle, key: String, value: CityUiModel) {
+        bundle.putString(key, Json.encodeToString(value))
+    }
 }
 
 // City Ui Model Mapper
@@ -24,7 +46,7 @@ fun CityEntity.toUiModel() = CityUiModel(
     name = name,
     id = id,
     coordinates = CityUiModel.CoordinatesUiModel(
-        lon = coordinates.lon,
+        lng = coordinates.lon,
         lat = coordinates.lat
     )
 )

--- a/app/src/main/java/com/klivvrassesment/ui/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/klivvrassesment/ui/navigation/MainNavHost.kt
@@ -1,0 +1,58 @@
+package com.klivvrassesment.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.dialog
+import androidx.navigation.toRoute
+import com.klivvrassesment.ui.models.CityUiModel
+import com.klivvrassesment.ui.screens.main.MainScreenRoot
+import com.klivvrassesment.ui.screens.maps.MapsScreenRoot
+
+val LocalNavController = compositionLocalOf<NavHostController> { error("No NavController found!") }
+
+@Composable
+fun MainNavHost(
+    modifier: Modifier = Modifier,
+    navController: NavHostController
+) {
+
+    CompositionLocalProvider(LocalNavController provides navController) {
+
+        NavHost(
+            navController = navController,
+            startDestination = MainScreens.MainScreen,
+        ) {
+
+            composable<MainScreens.MainScreen> {
+                MainScreenRoot(
+                    modifier = modifier
+                )
+            }
+
+            dialog<MainScreens.MapsScreen> {
+
+                val city = it.toRoute<MainScreens.MapsScreen>()
+
+                MapsScreenRoot(
+                    modifier = modifier,
+                    city = CityUiModel(
+                        country = city.country,
+                        name = city.name,
+                        id = 0,
+                        coordinates = CityUiModel.CoordinatesUiModel(
+                            lng = city.lng,
+                            lat = city.lat
+                        )
+                    )
+                )
+
+            }
+
+        }
+    }
+}

--- a/app/src/main/java/com/klivvrassesment/ui/navigation/MainScreens.kt
+++ b/app/src/main/java/com/klivvrassesment/ui/navigation/MainScreens.kt
@@ -1,0 +1,18 @@
+package com.klivvrassesment.ui.navigation
+
+import kotlinx.serialization.Serializable
+
+sealed interface MainScreens {
+
+    @Serializable
+    data object MainScreen : MainScreens
+
+    @Serializable
+    data class MapsScreen(
+        val lat: Double,
+        val lng: Double,
+        val name: String,
+        val country: String
+    ) : MainScreens
+
+}

--- a/app/src/main/java/com/klivvrassesment/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/com/klivvrassesment/ui/screens/main/MainScreen.kt
@@ -3,6 +3,7 @@ package com.klivvrassesment.ui.screens.main
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -36,6 +37,8 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import coil3.compose.AsyncImage
 import com.klivvrassesment.R
 import com.klivvrassesment.ui.models.CityListItem
+import com.klivvrassesment.ui.navigation.LocalNavController
+import com.klivvrassesment.ui.navigation.MainScreens
 import com.klivvrassesment.ui.utils.Constants.getFlagUrl
 import org.koin.androidx.compose.koinViewModel
 
@@ -45,12 +48,23 @@ fun MainScreenRoot(
 ) {
 
     val searchQuery = viewModel.searchQuery.collectAsStateWithLifecycle()
+    val navController = LocalNavController.current
 
     MainScreen(
         modifier = modifier,
         searchQuery = searchQuery.value,
         cities = viewModel.cities.collectAsLazyPagingItems(),
         onEvent = viewModel::onEvent,
+        onCityClick = {
+            navController.navigate(
+                MainScreens.MapsScreen(
+                    lat = it.city.coordinates.lat,
+                    lng = it.city.coordinates.lng,
+                    name = it.city.name,
+                    country = it.city.country
+                )
+            )
+        }
     )
 
 }
@@ -63,6 +77,7 @@ fun MainScreen(
     modifier: Modifier = Modifier,
     searchQuery: String,
     cities: LazyPagingItems<CityListItem>,
+    onCityClick: (CityListItem.CityItem) -> Unit,
     onEvent: (MainUiEvent) -> Unit
 ) {
 
@@ -121,6 +136,7 @@ fun MainScreen(
                             item(key = itemKey, contentType = contentType) {
                                 CityItem(
                                     city = (cities[index] as CityListItem.CityItem),
+                                    onCityClick = { onCityClick(cityListItem) }
                                 )
                             }
                         }
@@ -161,7 +177,9 @@ fun MainScreen(
 
 @Composable
 fun CityItem(
-    modifier: Modifier = Modifier, city: CityListItem.CityItem
+    modifier: Modifier = Modifier,
+    city: CityListItem.CityItem,
+    onCityClick: () -> Unit
 ) {
 
     Row(
@@ -194,6 +212,9 @@ fun CityItem(
                 )
                 .clip(MaterialTheme.shapes.medium)
                 .background(MaterialTheme.colorScheme.surface)
+                .clickable(
+                    onClick = onCityClick
+                )
                 .padding(16.dp), horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
 
@@ -222,7 +243,7 @@ fun CityItem(
                 Spacer(Modifier.height(8.dp))
 
                 Text(
-                    text = "${city.city.coordinates.lat}, ${city.city.coordinates.lon}",
+                    text = "${city.city.coordinates.lat}, ${city.city.coordinates.lng}",
                     color = MaterialTheme.colorScheme.onSurface,
                     style = MaterialTheme.typography.bodyMedium
                 )

--- a/app/src/main/java/com/klivvrassesment/ui/screens/maps/MapsScreen.kt
+++ b/app/src/main/java/com/klivvrassesment/ui/screens/maps/MapsScreen.kt
@@ -1,0 +1,53 @@
+package com.klivvrassesment.ui.screens.maps
+
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
+import com.google.maps.android.compose.rememberCameraPositionState
+import com.klivvrassesment.ui.models.CityUiModel
+
+@Composable
+fun MapsScreenRoot(
+    modifier: Modifier = Modifier,
+    city: CityUiModel
+) {
+
+    MapScreen(
+        modifier = modifier,
+        city = city
+    )
+
+}
+
+@Composable
+fun MapScreen(
+    modifier: Modifier = Modifier,
+    city: CityUiModel
+) {
+    val cairo = LatLng(city.coordinates.lat, city.coordinates.lng)
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition.fromLatLngZoom(cairo, 12f)
+    }
+
+    GoogleMap(
+        modifier = modifier
+            .fillMaxWidth(.9f)
+            .fillMaxHeight(.7f)
+            .clip(MaterialTheme.shapes.medium),
+        cameraPositionState = cameraPositionState
+    ) {
+        Marker(
+            state = remember { MarkerState(position = cairo) },
+            title = "${city.name}, ${city.country}",
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,11 +8,14 @@ espressoCore = "3.5.1"
 lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.09.00"
+mapsCompose = "6.6.0"
 paging="3.3.6"
+playServicesMaps = "19.2.0"
 serialization="1.8.1"
 koin = "4.0.0"
 coil = "3.2.0"
-
+maps-platform-secrets = "2.0.1"
+navigation = "2.9.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -30,6 +33,9 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 
+# Navigation
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
+
 # Paging3
 androidx-paging-runtime = { group = "androidx.paging", name = "paging-runtime", version.ref = "paging" }
 androidx-paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "paging" }
@@ -46,10 +52,12 @@ koin-test = { group = "io.insert-koin", name = "koin-test" }
 # Koil
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
+maps-compose = { module = "com.google.maps.android:maps-compose", version.ref = "mapsCompose" }
+play-services-maps = { module = "com.google.android.gms:play-services-maps", version.ref = "playServicesMaps" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-
+maps-platform-secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "maps-platform-secrets" }


### PR DESCRIPTION
This commit introduces Google Maps functionality to display the location of a selected city.

Key changes:
- Added `MainScreens` sealed interface to define navigation routes:
    - `MainScreen` for the city list.
    - `MapsScreen` (dialog) to display the map, taking latitude, longitude, city name, and country as parameters.
- Implemented `MainNavHost` to manage navigation between `MainScreenRoot` and `MapsScreenRoot`.
    - `LocalNavController` is provided for nested navigation.
    - `MapsScreen` is launched as a dialog, reconstructing `CityUiModel` from navigation arguments.
- Updated `MainActivity` to use `MainNavHost` with a `rememberNavController`.
- Added Google Maps Compose and Play Services Maps dependencies (`maps.compose`, `play.services.maps`).
- Added maps platform secrets plugin to `libs.versions.toml` and applied it in `app/build.gradle.kts`.
- Created `MapsScreen.kt` with `MapsScreenRoot` and `MapScreen` composables:
    - `MapScreen` displays a `GoogleMap` centered on the city's coordinates with a marker.
- Modified `MainScreen.kt`:
    - `MainScreenRoot` now uses `LocalNavController` to navigate to `MapsScreen` when a city is clicked.
    - `CityItem` composable now takes an `onCityClick` lambda.
- Updated `CityUiModel.kt`:
    - Renamed `lon` to `lng` in `CoordinatesUiModel` for consistency with Google Maps.
    - Made `CityUiModel` and `CoordinatesUiModel` `@Serializable`.
    - Added `CityUiModelNavType` for passing `CityUiModel` through navigation (currently unused, parameters are passed individually).
- Added necessary Google Maps API key placeholder and Play Services version meta-data in `AndroidManifest.xml`.
- Enabled `buildConfig` in `app/build.gradle.kts`.